### PR TITLE
Fix for declaration error

### DIFF
--- a/src/ColumnTogglerTrait.php
+++ b/src/ColumnTogglerTrait.php
@@ -14,7 +14,7 @@ use Laravel\Nova\Resource;
  */
 trait ColumnTogglerTrait
 {
-    public function serializeForIndex(NovaRequest $request, $fields = null): array
+    public function serializeForIndex(NovaRequest $request, $fields = null)
     {
         $indexFields = $fields ?? parent::indexFields($request);
 


### PR DESCRIPTION
Here is another small pull request.
The signature of ColumnTogglerTrait::serializeForIndex() differs from Laravel\Nova\Resource::serializeForIndex() and also from a package we use (Outl1ne\NovaSortable\Traits\HasSortableRows::serializeForIndex()).

(The signature in column-toggler contains a return type array, the other two sources do not contain a return type)

This leads to errors in my system:
Declaration of Outl1ne\NovaSortable\Traits\HasSortableRows::serializeForIndex(Laravel\Nova\Http\Requests\NovaRequest $request, $fields = null) must be compatible with App\Nova\Resource::serializeForIndex(Laravel\Nova\Http\Requests\NovaRequest $request, $fields = null): array 

Tested on Nova 4.29.5