### PR TITLE
Set column visibility by argument

### DIFF
--- a/src/ColumnTogglerServiceProvider.php
+++ b/src/ColumnTogglerServiceProvider.php
@@ -13,8 +13,8 @@ class ColumnTogglerServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
-        Field::macro('hideByDefault', function () {
-            return $this->withMeta([ 'columnToggleVisible' => false ]);
+        Field::macro('hideByDefault', function ($hiddenByDefault = true) {
+            return $this->withMeta([ 'columnToggleVisible' => !$hiddenByDefault ]);
         });
 
         Nova::serving(function (ServingNova $event): void {


### PR DESCRIPTION
Hi,

that change allow to set hideByDefault by flag, like:


```php
<?php

use Laravel\Nova\Http\Requests\NovaRequest;

class Resource extends NovaResource {
    public static bool $timestampsHiddenByDefault = false;
}

class User extends Resource
{
    public static bool $timestampsHiddenByDefault = true;

    public function fields(NovaRequest $request)
    {
        return [
            ID::make()->sortable(),
            DateTime::make('Created At')->hideByDefault(static::$timestampsHiddenByDefault)
        ];
    }
}
```