### PR TITLE
Consistent toggler view with checkbox filters

### DIFF
--- a/resources/js/components/ColumnToggler.vue
+++ b/resources/js/components/ColumnToggler.vue
@@ -40,7 +40,7 @@
                         <Draggable
                             v-model="state"
                             :disabled="enableSorting === false"
-                            class="flex flex-wrap p-4"
+                            class="flex flex-wrap p-4 space-y-2"
                             item-key="attribute"
                             :animation="150">
 

--- a/resources/js/components/ColumnToggler.vue
+++ b/resources/js/components/ColumnToggler.vue
@@ -40,14 +40,14 @@
                         <Draggable
                             v-model="state"
                             :disabled="enableSorting === false"
-                            class="flex flex-wrap p-4 space-y-1"
+                            class="flex flex-wrap p-4"
                             item-key="attribute"
                             :animation="150">
 
                             <template #item="{ element }">
 
                                 <CheckboxWithLabel
-                                    class="w-full leading-none whitespace-nowrap"
+                                    class="w-full whitespace-nowrap"
                                     v-if="element.label"
                                     :checked="element.visible"
                                     @click.stop


### PR DESCRIPTION
Hi,

checkbox filters looks that:
<img width="259" alt="image" src="https://github.com/dcasia/column-toggler/assets/855788/dd7d22e1-126f-4968-a670-5dbf5a69647e">

and column toggler that:
<img width="257" alt="image" src="https://github.com/dcasia/column-toggler/assets/855788/645df4a7-3925-49fb-9448-9f01967027f0">

There is an inconsistency in the spacing between elements, and this PR fix this :)